### PR TITLE
Use Npm task

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,12 +9,15 @@ steps:
     versionSpec: '8.x'
   
 - task: Npm@1
+  displayName: 'npm install'
   inputs:
     command: install
 
 - task: Npm@1
+  displayName: 'npm test'
   inputs:
-    command: test
+    command: custom
+    customCommand: 'test'
 
 - task: PublishTestResults@2
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,9 +8,13 @@ steps:
   inputs:
     versionSpec: '8.x'
   
-- script: |
-    npm install
-    npm test
+- task: Npm@1
+  inputs:
+    command: install
+
+- task: Npm@1
+  inputs:
+    command: test
 
 - task: PublishTestResults@2
   inputs:


### PR DESCRIPTION
The `Npm` task is better to use than a `script` command because it correctly injects credentials and other config