### PR TITLE
Use npm task so authenticated feeds automatically work

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,9 +8,11 @@ steps:
   inputs:
     versionSpec: '8.x'
   
-- script: |
-    npm install
-    npm test
+- task: Npm@1
+    inputs:
+      command: install
+
+- script: npm test
 
 - task: PublishTestResults@2
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,8 +9,8 @@ steps:
     versionSpec: '8.x'
   
 - task: Npm@1
-    inputs:
-      command: install
+  inputs:
+    command: install
 
 - script: npm test
 


### PR DESCRIPTION
To make authenticated (Azure Artifacts) feeds work by default, can we move from a script step to the npm task step?